### PR TITLE
add auto upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,8 @@ RUN echo "NETWORK='$NETWORK'" > ./creator-node/.env
 RUN echo "NETWORK='$NETWORK'" > ./discovery-provider/.env
 RUN echo "NETWORK='$NETWORK'" > ./identity-service/.env
 
+RUN cp "./discovery-provider/chain/${NETWORK}_spec_template.json" "./discovery-provider/chain/spec.json"
+RUN echo '[]' > ./discovery-provider/chain/static-nodes.json
+
 RUN python3 -m pip install -r requirements.txt
 RUN ln -sf $PWD/audius-cli /usr/local/bin/audius-cli

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var tlsPort int
 var network string
 var nodeType string
 var seed bool
+var autoUpgrade bool
 
 // with the intent of reducing configuration,
 // the latest audius-docker-compose sha (from stage branch) is set at build time via ci.
@@ -37,6 +38,7 @@ func main() {
 	flag.StringVar(&network, "network", "prod", "specify the network to run on")
 	flag.StringVar(&nodeType, "node", "creator-node", "specify the node type to run")
 	flag.BoolVar(&seed, "seed", false, "seed data (only applicable to discovery-provider)")
+	flag.BoolVar(&autoUpgrade, "autoUpgrade", true, "runs cron job to keep node on the latest version")
 
 	fmt.Printf("imageTag: audius/audius-docker-compose:%s\n", imageTag)
 
@@ -153,6 +155,10 @@ func runUp() {
 		audiusCli("launch", "identity-service", "-y")
 	default:
 		exitWithError(fmt.Sprintf("provided node type is not supported: %s", nodeType))
+	}
+
+	if autoUpgrade {
+		audiusCli("auto-upgrade")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -158,7 +158,9 @@ func runUp() {
 	}
 
 	if autoUpgrade {
+		fmt.Println("setting auto-upgrade")
 		audiusCli("auto-upgrade")
+		fmt.Println("auto-upgrade enabled")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -138,6 +138,12 @@ func runUp() {
 		configureChainSpec()
 	}
 
+	if autoUpgrade {
+		fmt.Println("setting auto-upgrade")
+		audiusCli("auto-upgrade")
+		fmt.Println("auto-upgrade enabled")
+	}
+
 	switch nodeType {
 	case "creator-node":
 		execCmd := fmt.Sprintf(`docker exec %s sh -c "cd %s && docker compose up -d"`, nodeType, nodeType)
@@ -155,12 +161,6 @@ func runUp() {
 		audiusCli("launch", "identity-service", "-y")
 	default:
 		exitWithError(fmt.Sprintf("provided node type is not supported: %s", nodeType))
-	}
-
-	if autoUpgrade {
-		fmt.Println("setting auto-upgrade")
-		audiusCli("auto-upgrade")
-		fmt.Println("auto-upgrade enabled")
 	}
 }
 


### PR DESCRIPTION
`auto_upgrade` in the discovery health check is enabled!
```
{
  "comms": {
    "booted": "2023-10-31T16:32:04Z",
    "built": "",
    "commit": "",
    "errors": null,
    "healthy": false,
    "host": "https://localhost",
    "is_registered_wallet": false,
    "wallet": "0xb3c66e682Bf9a85F6800c769AC5A05c18C3F331d",
    "websocket_error": {
      "Addr": {
        "IP": "127.0.0.1",
        "Port": 443,
        "Zone": ""
      },
      "Err": {
        "Err": 111,
        "Syscall": "connect"
      },
      "Net": "tcp",
      "Op": "dial",
      "Source": null
    }
  },
  "data": {
    "audius-docker-compose": "bd587a0fda42248668f56fa8d0b8217358fb188f",
    "auto_upgrade_enabled": true,
    "block_difference": 54724282,
    "chain_health": {
      "block_number": 22454423,
      "chain_id": 1056801,
      "entries": {
        "node-health": {
          "data": {},
          "description": "The node is now fully synced with a network. Peers: 3.",
          "duration": "00:00:00.0000264",
          "status": "Healthy",
          "tags": []
        }
      },
      "hash": "0xd753a3c4d6fd2bc5c4a2f9b46d414b73dc4ef1adf76f11ffedaecdf72bddc07e",
      "signers": [
        "0x5e98cbeeaa2acedec0833ac3d1634e2a7ae0f3c2",
        "0x8fcfa10bd3808570987dbb5b1ef4ab74400fbfda",
        "0xf7c96916bd37ad76d4eedd6536b81c29706c8056"
      ],
      "snapshot": {
        "hash": "0xd753a3c4d6fd2bc5c4a2f9b46d414b73dc4ef1adf76f11ffedaecdf72bddc07e",
        "number": "0x156a097",
        "signerLimit": "0x2",
        "signers": {
          "0x5e98cbeeaa2acedec0833ac3d1634e2a7ae0f3c2": "0x156a095",
          "0x8fcfa10bd3808570987dbb5b1ef4ab74400fbfda": "0x156a096",
          "0xf7c96916bd37ad76d4eedd6536b81c29706c8056": "0x156a097"
        },
        "votes": []
      },
      "status": "Healthy",
      "totalDuration": "00:00:00.0002317"
    },
    "challenge_last_event_age_sec": null,
    "database_connections": null,
    "database_is_localhost": true,
    "database_size": null,
    "db": {
      "blockhash": "0x0",
      "number": 0
    },
    "discovery_provider_healthy": true,
    "errors": [],
    "filesystem_size": null,
    "filesystem_used": null,
    "final_poa_block": 32269859,
    "git": "e176fece62be591c420e9f789bf1e8db0669bf45",
    "index_eth_age_sec": null,
    "infra_setup": "audius-docker-compose",
    "last_scanned_block_for_balance_refresh": null,
    "latest_block_num": 54724282,
    "latest_indexed_block_num": 0,
    "maximum_healthy_block_difference": 100,
    "meets_min_requirements": false,
    "network": {
      "content_nodes": null,
      "discovery_nodes": null
    },
    "num_users_in_immediate_balance_refresh_queue": 0,
    "num_users_in_lazy_balance_refresh_queue": 0,
    "number_of_cpus": 8,
    "openresty_public_key": "-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQEAyeVThZ6vVzjdxmnnURK6Jfj52AQ99i8XJOH4Mb/xOySM2SbdIrlo\nJF3QEg8GIfoi7Ln0pEhQMEYRytKBvlyu1c0rYDKUumyu53BZM5hpWqF72sVuWWxz\n5B036JZph+qk02EURTuSCCdVJcwCKrk88bsekAjo/O0MuUF9lhiN3PsGNUvi0Kdi\nsxNU74QuMf+Yr84n0TfmVB3wnmW985vdtKzf4Zwhk7vR4CeoQU/MhtAHCyvaP0VM\nk9KwkdRUVuIyzZAo5hVrg4xaYIgdunnYtqIqgzwbL0TT9cTMo50W4of2v9pYNz5Y\nM7MC2YzlbT241ExQv+lFse3siXAbmkVbAQIDAQAB\n-----END RSA PUBLIC KEY-----\n\n",
    "plays": {
      "is_unhealthy": false,
      "oldest_unarchived_play_created_at": "2022-04-03 18:00:04",
      "time_diff_general": 49732462.506967,
      "tx_info": {
        "slot_diff": -1,
        "time_diff": -1,
        "tx_info": {
          "chain_tx": null,
          "db_tx": {
            "signature": "32QkFC2iT8f5dokaVWRyiV4QVWGqAiXAkUZqq9meoXwyDss6tnT4BEfVYFevYi9VBER27dH9DS8xb4UYqSi3sCWM",
            "slot": 128110286,
            "timestamp": 1649038478
          }
        }
      }
    },
    "reactions": {
      "indexing_delta": null,
      "is_unhealthy": false,
      "reaction_delta": null
    },
    "received_bytes_per_sec": null,
    "redis_total_memory": null,
    "relay": {
      "is_unhealthy": false,
      "status": "up"
    },
    "rewards_manager": {
      "is_unhealthy": false,
      "time_diff_general": -1,
      "tx_info": {
        "slot_diff": -1,
        "time_diff": -1,
        "tx_info": {
          "chain_tx": null,
          "db_tx": {
            "signature": "a9e6nenV8856NezhYAozPhDrsXY7rtdR4w6jSR2RJHUksiq5ENrb1X47gysGuP2yvBucgC9HTaEaHiXpyDxYSUV",
            "slot": 226983719,
            "timestamp": 1698693172
          }
        }
      }
    },
    "service": "discovery-node",
    "spl_audio_info": {
      "is_unhealthy": false,
      "time_diff_general": -1,
      "tx_info": {
        "slot_diff": -1,
        "time_diff": -1,
        "tx_info": {
          "chain_tx": null,
          "db_tx": {
            "signature": "4mfxoKjfGiGMEWtCtQsCCvVmMkW4rnDRPmjjRDaSxTezs3t3tfHKbngh18F8b5kTxsftmjdcUMVm1JiWA3jG9Ars",
            "slot": 225734558,
            "timestamp": 1697721256
          }
        }
      }
    },
    "total_memory": null,
    "transferred_bytes_per_sec": null,
    "trending_playlists_age_sec": null,
    "trending_tracks_age_sec": null,
    "url": "https://localhost",
    "used_memory": null,
    "user_balances_age_sec": null,
    "user_bank": {
      "is_unhealthy": false,
      "time_diff_general": -1,
      "tx_info": {
        "slot_diff": -1,
        "time_diff": -1,
        "tx_info": {
          "chain_tx": null,
          "db_tx": {
            "signature": "4yarvXMsM4HXr1FoMU8GNyLyri78qVyHDTBCQANhNuTKW1tt3WQ1FZnNrN8GoLuuGmYgj5yD3rEbmm7X41CAvLEr",
            "slot": 226954206,
            "timestamp": 1698680693
          }
        }
      }
    },
    "version": "0.5.4",
    "web": {
      "blockhash": "0xd753a3c4d6fd2bc5c4a2f9b46d414b73dc4ef1adf76f11ffedaecdf72bddc07e",
      "blocknumber": 54724282
    }
  },
  "latest_chain_block": 54724282,
  "latest_chain_slot_plays": null,
  "latest_indexed_block": null,
  "latest_indexed_slot_plays": 128110286,
  "signer": "0xb3c66e682Bf9a85F6800c769AC5A05c18C3F331d",
  "success": true,
  "version": {
    "service": "discovery-node",
    "version": "0.5.4"
  }
}
```