### PR TITLE
Add more context commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,8 @@ commands:
           name: standup audius node
           command: |
             cd ~/audius-d
-            mkdir ~/.audius
-            cp ~/audius-d/sample.audius.conf "$HOME/.audius/<< parameters.nodetype >>.conf"
-            audius-d-x86 -c "$HOME/.audius/<< parameters.nodetype >>.conf" -network=stage -node '<< parameters.nodetype >>'
+            audius-d-x86 config create-context ci -f templates/devnet.toml 
+            audius-d-x86
   standup-devnet:
     description: 'Stand up external dev chain containers for eth, sol, and acdc'
     steps:

--- a/conf/context.go
+++ b/conf/context.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -44,7 +45,7 @@ func ReadOrCreateContextConfig() (*ContextConfig, error) {
 	if _, err = os.Stat(contextFilePath); os.IsNotExist(err) {
 		fmt.Printf("Context '%s' not found, creating default.\n", execConf.CurrentContext)
 		createDefaultContext(contextFilePath)
-		err = SetContext("default")
+		err = UseContext("default")
 		if err != nil {
 			return nil, err
 		}
@@ -88,7 +89,26 @@ func GetContext() (string, error) {
 	return execConf.CurrentContext, nil
 }
 
-func SetContext(ctxName string) error {
+func GetContexts() ([]string, error) {
+	ctxDir, err := getContextBaseDir()
+	if err != nil {
+		return nil, err
+	}
+	files, err := ioutil.ReadDir(ctxDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var ret []string
+	for _, file := range files {
+		if !file.IsDir() {
+			ret = append(ret, file.Name())
+		}
+	}
+	return ret, nil
+}
+
+func UseContext(ctxName string) error {
 	ctxDir, err := getContextBaseDir()
 	if err != nil {
 		return err
@@ -100,7 +120,7 @@ func SetContext(ctxName string) error {
 
 	if _, err := os.Stat(filepath.Join(ctxDir, ctxName)); os.IsNotExist(err) {
 		fmt.Printf("No context named %s\n", ctxName)
-		return err
+		return nil
 	}
 
 	var execConf ExecutionConfig
@@ -109,6 +129,22 @@ func SetContext(ctxName string) error {
 	}
 	execConfFilePath := filepath.Join(confBaseDir, "audius")
 	if err = writeConfigToFile(execConfFilePath, &execConf); err != nil {
+		return err
+	}
+	return nil
+}
+
+func DeleteContext(ctxName string) error {
+	ctxDir, err := getContextBaseDir()
+	if err != nil {
+		return err
+	}
+	ctxFilepath := filepath.Join(ctxDir, ctxName)
+	if _, err := os.Stat(ctxFilepath); os.IsNotExist(err) {
+		fmt.Printf("No context named %s\n", ctxName)
+		return nil
+	}
+	if err := os.Remove(ctxFilepath); err != nil {
 		return err
 	}
 	return nil
@@ -136,10 +172,15 @@ func writeConfigToContext(ctxName string, ctxConfig *ContextConfig) error {
 	return err
 }
 
-func createContextFromTemplate(name string, templateFilePath string) {
+func createContextFromTemplate(name string, templateFilePath string) error {
 	var ctxConfig ContextConfig
-	readConfigFromFile(templateFilePath, &ctxConfig)
-	writeConfigToContext(name, &ctxConfig)
+	if err := readConfigFromFile(templateFilePath, &ctxConfig); err != nil {
+		return err
+	}
+	if err := writeConfigToContext(name, &ctxConfig); err != nil {
+		return err
+	}
+	return nil
 }
 
 func createExecutionConfig(confFilePath string) error {

--- a/conf/root.go
+++ b/conf/root.go
@@ -4,51 +4,102 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/spf13/cobra"
 )
 
-var RootCmd = &cobra.Command{
-	Use:   "config [command]",
-	Short: "view/modify audius-d configuration",
-	Run: func(cmd *cobra.Command, args []string) {
-		spew.Dump(cmd.Context().Value(ContextKey).(*ContextConfig))
-	},
-}
-var confFileTemplate string
-var createContextCmd = &cobra.Command{
-	Use:   "create-context <name> [options]",
-	Short: "view/modify audius-d configuration",
-	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		createContextFromTemplate(args[0], confFileTemplate)
-	},
-}
-var getContextCmd = &cobra.Command{
-	Use:   "get-context",
-	Short: "Show the currently enabled context",
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx, err := GetContext()
-		if err != nil {
-			log.Fatal("Failed to retrieve current context", err)
-		}
-		fmt.Println(ctx)
-	},
-}
-var setContextCmd = &cobra.Command{
-	Use:   "set-context <context>",
-	Short: "Switch to a different context",
-	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		err := SetContext(args[0])
-		if err != nil {
-			log.Fatal("Failed to set context", err)
-		}
-		fmt.Printf("Context set to %s\n", args[0])
-	},
-}
+var (
+	RootCmd = &cobra.Command{
+		Use:   "config [command]",
+		Short: "view/modify audius-d configuration",
+		Run: func(cmd *cobra.Command, args []string) {
+			dumpCmd.Run(cmd, args)
+		},
+	}
+
+	dumpOutfile string
+	dumpCmd     = &cobra.Command{
+		Use:   "dump [-o outfile]",
+		Short: "dump current config to stdout or a file",
+		Run: func(cmd *cobra.Command, args []string) {
+			if dumpOutfile != "" {
+				err := writeConfigToFile(dumpOutfile, cmd.Context().Value(ContextKey).(*ContextConfig))
+				if err != nil {
+					log.Fatal("Failed to write config to file:", err)
+				}
+			} else {
+				str, err := stringifyConfig(cmd.Context().Value(ContextKey).(*ContextConfig))
+				if err != nil {
+					log.Fatal("Failed to dump config:", err)
+				}
+				fmt.Println(str)
+			}
+		},
+	}
+
+	confFileTemplate string
+	createContextCmd = &cobra.Command{
+		Use:   "create-context <name> [options]",
+		Short: "view/modify audius-d configuration",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := createContextFromTemplate(args[0], confFileTemplate)
+			if err != nil {
+				log.Fatal("Failed to create context:", err)
+			}
+			useContextCmd.Run(cmd, args)
+		},
+	}
+	getContextCmd = &cobra.Command{
+		Use:   "get-context",
+		Short: "Show the currently enabled context",
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx, err := GetContext()
+			if err != nil {
+				log.Fatal("Failed to retrieve current context", err)
+			}
+			fmt.Println(ctx)
+		},
+	}
+	getContextsCmd = &cobra.Command{
+		Use:   "get-contexts",
+		Short: "Show all available contexts",
+		Run: func(cmd *cobra.Command, args []string) {
+			ctxs, err := GetContexts()
+			if err != nil {
+				log.Fatal("Failed to retrieve current context", err)
+			}
+			for _, ctx := range ctxs {
+				fmt.Println(ctx)
+			}
+		},
+	}
+	useContextCmd = &cobra.Command{
+		Use:   "use-context <context>",
+		Short: "Switch to a different context",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := UseContext(args[0])
+			if err != nil {
+				log.Fatal("Failed to set context", err)
+			}
+			fmt.Printf("Context set to %s\n", args[0])
+		},
+	}
+	deleteContextCmd = &cobra.Command{
+		Use:   "delete-context <context>",
+		Short: "Delete a context",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := DeleteContext(args[0]); err != nil {
+				log.Fatal("Failed to delete context", err)
+			}
+			fmt.Printf("Context %s deleted.\n", args[0])
+		},
+	}
+)
 
 func init() {
 	createContextCmd.Flags().StringVarP(&confFileTemplate, "templatefile", "f", "", "-f <config file to build context from>")
-	RootCmd.AddCommand(createContextCmd, getContextCmd, setContextCmd)
+	dumpCmd.Flags().StringVarP(&dumpOutfile, "outfile", "o", "", "-o <outfile")
+	RootCmd.AddCommand(dumpCmd, createContextCmd, getContextCmd, getContextsCmd, useContextCmd, deleteContextCmd)
 }

--- a/conf/toml.go
+++ b/conf/toml.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"bytes"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -38,4 +39,12 @@ func writeConfigToFile(confFilePath string, config interface{}) error {
 		return err
 	}
 	return nil
+}
+
+func stringifyConfig(config interface{}) (string, error) {
+	buf := new(bytes.Buffer)
+	if err := toml.NewEncoder(buf).Encode(config); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }


### PR DESCRIPTION
## Description

More quality-of-life context commands like get-contexts and delete-context. Also, `audius-d config` or `audius-d config dump` now dumps the current config to stdout in toml format. You can also specify `audius-d config dump -o my_outfile.toml` if you want to be more explicit than `audius-d config > my_outfile.toml`