### PR TITLE
use-context fix

### DIFF
--- a/conf/context.go
+++ b/conf/context.go
@@ -127,6 +127,10 @@ func UseContext(ctxName string) error {
 	if err = readExecutionConfig(&execConf); err != nil {
 		return err
 	}
+
+	// set new name and rewrite file
+	execConf.CurrentContext = ctxName
+
 	execConfFilePath := filepath.Join(confBaseDir, "audius")
 	if err = writeConfigToFile(execConfFilePath, &execConf); err != nil {
 		return err


### PR DESCRIPTION
context wasn't changed when using `use-context`

testing:
open the `./audius` folder and watch the `audius` file, it holds the current context in the `CurrentContext` field

upon running `./dev config use-context ${your ctx here}` it should change to what you passed in

previously it would stay at `default`