### PR TITLE
[PROTO-1610] Allow commit hash in Version to pin audius service images

### DIFF
--- a/cmd/audius-ctl/hash.go
+++ b/cmd/audius-ctl/hash.go
@@ -22,11 +22,11 @@ func init() {
 				for _, arg := range args {
 					val, err := strconv.Atoi(arg)
 					if err != nil {
-						logger.ErrorF("invalid number: %s \n", arg)
+						logger.Errorf("invalid number: %s \n", arg)
 						continue
 					}
 					if hashed, err := hashes.Encode(val); err != nil {
-						logger.ErrorF("invalid input: %s \n", arg)
+						logger.Errorf("invalid input: %s \n", arg)
 					} else {
 						logger.Out(hashed)
 					}
@@ -39,7 +39,7 @@ func init() {
 			RunE: func(cmd *cobra.Command, args []string) error {
 				for _, arg := range args {
 					if num, err := hashes.MaybeDecode(arg); err != nil {
-						logger.ErrorF("invalid input: %s \n", arg)
+						logger.Errorf("invalid input: %s \n", arg)
 					} else {
 						logger.Out(num)
 					}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -64,7 +64,7 @@ func Warnf(format string, v ...any) {
 	stderrLogger.Warn(fmsg)
 }
 
-func ErrorF(format string, v ...any) error {
+func Errorf(format string, v ...any) error {
 	emsg := fmt.Sprintf(format, v...)
 	return Error(emsg)
 }

--- a/pkg/orchestration/docker.go
+++ b/pkg/orchestration/docker.go
@@ -219,7 +219,6 @@ func configureAutoUpgrade(containerName string, hourly bool) error {
 
 func startDevnetDocker() {
 	logger.Info("Creating docker network")
-	runCommand("docker", "network", "create", "--subnet=172.100.0.0/16", "--gateway=172.100.0.1", "deployments_devnet")
 	logger.Info("Starting local eth, sol, and acdc chains")
 	runCommand("docker", "compose", "-f", "./deployments/docker-compose.devnet.yml", "up", "-d")
 	time.Sleep(5 * time.Second)
@@ -227,7 +226,6 @@ func startDevnetDocker() {
 
 func downDevnetDocker() {
 	runCommand("docker", "compose", "-f", "./deployments/docker-compose.devnet.yml", "down")
-	runCommand("docker", "network", "rm", "deployments_devnet")
 }
 
 func audiusCli(container string, args ...string) error {


### PR DESCRIPTION
This will allow devs to set the `Version` config to the same git commit hash that is used to tag service containers built from audius-protocol. It's the same as using `audius-cli set-tag <commit-hash>` in audius-docker-compose.

The logic of version configuration in audius-d is as follows:
* "current" -> uses "main" audius-docker-compose branch, auto updates hourly.
* "prerelease" -> uses "stage" audius-docker-compose branch, auto updates every minute
* "some-branch-name" -> uses "some-branch-name" audius-docker-compose branch, auto updates every minute
* "afd269f8df98d999..." (40-character hash) -> uses "stage" audius-docker-compose branch, does not auto update, pins audius-protocol containers to the version in the hash. **For development testing only.**