### PR TITLE
Update dockerfile, wait for wrapper to be ready

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM docker:dind
 
 RUN apk add bash git curl libc-dev gcc python3 py3-pip python3-dev linux-headers postgresql-client redis
 
-VOLUME /var/k8s/creator-node-db
-VOLUME /var/k8s/mediorum
-VOLUME /var/k8s/discovery-provider-db
-VOLUME /var/k8s/discovery-provider-chain
+VOLUME ["/var/k8s/creator-node-db-15", "/var/k8s/mediorum", "/var/k8s/creator-node-backend"]
+VOLUME ["/var/k8s/discovery-provider-db", "/var/k8s/discovery-provider-chain"]
+VOLUME ["/var/k8s/identity-service-db"]
 
 WORKDIR /root
 RUN git clone https://github.com/AudiusProject/audius-docker-compose.git ./audius-docker-compose

--- a/pkg/orchestration/side_effects.go
+++ b/pkg/orchestration/side_effects.go
@@ -33,7 +33,7 @@ func awaitService(host string, awaitChan chan string) {
 		resp, err := client.Get(url)
 
 		if err != nil || resp.StatusCode != http.StatusOK {
-			awaitChan <- fmt.Sprintf("service: %s not ready yet", url)
+			awaitChan <- fmt.Sprintf("service: %s not ready yet...", url)
 			time.Sleep(3 * time.Second)
 			tries--
 			continue


### PR DESCRIPTION
When using the docker golang sdk, containers are started asynchronously. This will introduce a delay and ensure the container is in the running state before continuing with the audius protocol launch.

Also updated the Dockerfile, tested successfully on stage-creator-7.