### PR TITLE
Restore chain spec template behavior

### DIFF
--- a/pkg/orchestration/docker.go
+++ b/pkg/orchestration/docker.go
@@ -270,7 +270,11 @@ func runNode(
 		network = "dev"
 	}
 	audiusCli(dockerClient, host, "set-network", network)
+	if err := dockerExec(dockerClient, host, "cp", fmt.Sprintf("./discovery-provider/chain/%s_spec_template.json", network), "./discovery-provider/chain/spec.json"); err != nil {
+		return logger.Error(err)
+	}
 
+	// launch the protocol stack
 	if err := audiusCli(dockerClient, host, "launch", "-y", adcDir); err != nil {
 		return logger.Error(err)
 	}


### PR DESCRIPTION
Need to provide a chain spec so that discprov starts properly. This used to be in the Dockerfile but has been restored here since we can specify it dynamically.