### PR TITLE
Don't copy chain spec, audius-cli already does

### DIFF
--- a/pkg/orchestration/docker.go
+++ b/pkg/orchestration/docker.go
@@ -270,9 +270,6 @@ func runNode(
 		network = "dev"
 	}
 	audiusCli(dockerClient, host, "set-network", network)
-	if err := dockerExec(dockerClient, host, "cp", fmt.Sprintf("./discovery-provider/chain/%s_spec_template.json", network), "./discovery-provider/chain/spec.json"); err != nil {
-		return logger.Error(err)
-	}
 
 	// launch the protocol stack
 	if err := audiusCli(dockerClient, host, "launch", "-y", adcDir); err != nil {


### PR DESCRIPTION
[audius-cli already takes care of this](https://github.com/AudiusProject/audius-docker-compose/blob/main/audius-cli#L1019), doing it ourselves creates strange errors. 

Tested by spinning up stage dn4