### PR TITLE
Add discovery chain peering ports

### DIFF
--- a/pkg/orchestration/docker.go
+++ b/pkg/orchestration/docker.go
@@ -116,6 +116,10 @@ func runNode(
 	httpPorts := fmt.Sprintf("%d:%d", port, port)
 	httpsPorts := fmt.Sprintf("%d:%d", tlsPort, tlsPort)
 	allPorts := []string{httpPorts, httpsPorts}
+	if config.Type == conf.Discovery {
+		// Required for chain peering and discovery
+		allPorts = append(allPorts, "30300:30300", "30300:30300/udp")
+	}
 	if config.HostPorts != "" {
 		allPorts = append(allPorts, strings.Split(config.HostPorts, ",")...)
 	}


### PR DESCRIPTION
Discovery nodes can't peer to one another without these ports exposed. Note the discrepancy in number of peers in stage healthz discovery for audius-d nodes vs adc node.

Tested on stage dn5