### PR TITLE
Add host and context dynamic autocompletions and restart command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
           name: Test restart node
           command: |
             cd ~/audius-d
+            IMAGE_TAG="$(sha1sum ./Dockerfile | awk '{print $1}')"
             audius-ctl restart discovery-1.devnet.audius-d -w -f --audius-d-version $IMAGE_TAG
             audius-ctl status
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,12 @@ jobs:
             cd ~/audius-d
             audius-ctl status
       - run:
+          name: Test restart node
+          command: |
+            cd ~/audius-d
+            audius-ctl restart discovery-1.devnet.audius-d -w -f --audius-d-version $IMAGE_TAG
+            audius-ctl status
+      - run:
           name: Teardown
           command: |
             cd ~/audius-d

--- a/cmd/audius-ctl/main.go
+++ b/cmd/audius-ctl/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	rootCmd.Flags().BoolVarP(&displayVersion, "version", "v", false, "Display version info")
-	rootCmd.AddCommand(configCmd, devnetCmd, downCmd, infraCmd, registerCmd, sbCmd, testCmd, upCmd)
+	rootCmd.AddCommand(configCmd, devnetCmd, downCmd, infraCmd, registerCmd, restartCmd, sbCmd, testCmd, upCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/audius-ctl/up.go
+++ b/cmd/audius-ctl/up.go
@@ -16,68 +16,45 @@ var (
 	awaitHealthy = false
 	audiusdTag   = "default"
 	upCmd        = &cobra.Command{
-		Use:   "up [hosts]",
-		Short: "Spin up the audius nodes specified in your config, optionally specifying which hosts.",
+		Use:               "up [hosts]",
+		Short:             "Spin up the audius nodes specified in your config, optionally specifying which hosts.",
+		ValidArgsFunction: hostsCompletionFunction,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var nodesToRunUp map[string]conf.NodeConfig
-			var err error
-			ctx := readOrCreateContext()
-			if len(args) == 0 {
-				nodesToRunUp = ctx.Nodes
-			} else {
-				nodesToRunUp, err = filterNodesFromContext(args, ctx)
-				if err != nil {
-					return err
-				}
-			}
-			orchestration.RunAudiusNodes(nodesToRunUp, ctx.Network, awaitHealthy, audiusdTag)
-			return nil
+			return runUpNodes(awaitHealthy, audiusdTag, args)
 		},
 	}
 
 	downAll   = false
 	downForce = false
 	downCmd   = &cobra.Command{
-		Use:   "down [hosts] [--all/-a, --force/-f]",
-		Short: "Spin down nodes and network in the current context.",
+		Use:               "down [HOST ...] [--all/-a, --force/-f]",
+		Short:             "Spin down nodes and network in the current context.",
+		ValidArgsFunction: hostsCompletionFunction,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if downAll && len(args) > 0 {
-				return logger.Error("Cannot combine specific nodes with flag --all/-a.")
-			} else if !downAll && len(args) == 0 {
-				return logger.Error("Must specify which nodes to take down or use --all/-a.")
-			}
+			return runDownNodes(downAll, downForce, args)
+		},
+	}
 
-			ctx := readOrCreateContext()
-			var nodesToRunDown map[string]conf.NodeConfig
-			var err error
-			if downAll {
-				nodesToRunDown = ctx.Nodes
-			} else {
-				nodesToRunDown, err = filterNodesFromContext(args, ctx)
-				if err != nil {
-					return err
-				}
+	restartCmd = &cobra.Command{
+		Use:               "restart [HOST ...] [--all/-a, --force/-f, -w/--await-healthy]",
+		Short:             "Fully turn down and then turn up audius-d.",
+		ValidArgsFunction: hostsCompletionFunction,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := runDownNodes(downAll, downForce, args); err != nil {
+				// assumes err is returned due to cancellation or bad arguments because run down failures are skipped.
+				return err
 			}
-
-			infoString := "This will run down the following nodes:"
-			for host := range nodesToRunDown {
-				infoString += fmt.Sprintf("\n%s", host)
-			}
-			logger.Info(infoString)
-
-			if !downForce && !askForConfirmation("Are you sure you want to continue?") {
-				return logger.Error("Aborted")
-			}
-
-			orchestration.RunDownNodes(nodesToRunDown)
-			return nil
+			return runUpNodes(awaitHealthy, audiusdTag, args)
 		},
 	}
 	devnetCmd = &cobra.Command{
 		Use:   "devnet [command]",
 		Short: "Spin up local ethereum, solana, and acdc chains for development",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := readOrCreateContext()
+			ctx, err := readOrCreateContext()
+			if err != nil {
+				return logger.Error("Could not get current context:", err)
+			}
 			return orchestration.StartDevnet(ctx)
 		},
 	}
@@ -85,7 +62,10 @@ var (
 		Use:   "down",
 		Short: "Shut down local ethereum, solana, and acdc chains",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := readOrCreateContext()
+			ctx, err := readOrCreateContext()
+			if err != nil {
+				return logger.Error("Could not get current context:", err)
+			}
 			return orchestration.DownDevnet(ctx)
 		},
 	}
@@ -96,16 +76,42 @@ func init() {
 	upCmd.Flags().StringVar(&audiusdTag, "audius-d-version", "default", "(Development) override docker image tag to use (audius/audius-d:<version>)")
 	downCmd.Flags().BoolVarP(&downAll, "all", "a", false, "Take down all nodes in the current configuration.")
 	downCmd.Flags().BoolVarP(&downForce, "force", "f", false, "Do not ask for confirmation.")
+	restartCmd.Flags().BoolVarP(&awaitHealthy, "await-healthy", "w", false, "Wait for services to become healthy before returning.")
+	restartCmd.Flags().StringVar(&audiusdTag, "audius-d-version", "default", "(Development) override docker image tag to use (audius/audius-d:<version>)")
+	restartCmd.Flags().BoolVarP(&downAll, "all", "a", false, "Take down all nodes in the current configuration.")
+	restartCmd.Flags().BoolVarP(&downForce, "force", "f", false, "Do not ask for confirmation.")
 	devnetCmd.AddCommand(devnetDownCmd)
 }
 
-func readOrCreateContext() *conf.ContextConfig {
+func readOrCreateContext() (*conf.ContextConfig, error) {
 	ctx_config, err := conf.ReadOrCreateContextConfig()
 	if err != nil {
-		logger.Error("Failed to retrieve context: ", err)
-		return nil
+		return nil, logger.Error("Failed to retrieve context: ", err)
 	}
-	return ctx_config
+	return ctx_config, nil
+}
+
+func hostsCompletionFunction(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	hosts, err := getAvailableHostsWithPrefix(toComplete)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return hosts, cobra.ShellCompDirectiveNoFileComp
+}
+
+func getAvailableHostsWithPrefix(prefix string) ([]string, error) {
+	ctx, err := readOrCreateContext()
+	if err != nil {
+		return nil, logger.Error("Could not get current context:", err)
+	}
+	hosts := make([]string, 0)
+	for host, _ := range ctx.Nodes {
+		if strings.HasPrefix(host, prefix) {
+			hosts = append(hosts, host)
+		}
+	}
+	return hosts, nil
 }
 
 func filterNodesFromContext(desired []string, ctx *conf.ContextConfig) (map[string]conf.NodeConfig, error) {
@@ -146,4 +152,57 @@ func askForConfirmation(s string) bool {
 			return false
 		}
 	}
+}
+
+func runDownNodes(all bool, force bool, hosts []string) error {
+	if all && len(hosts) > 0 {
+		return logger.Error("Cannot combine specific nodes with flag --all/-a.")
+	} else if !all && len(hosts) == 0 {
+		return logger.Error("Must specify which nodes to take down or use --all/-a.")
+	}
+
+	ctx, err := readOrCreateContext()
+	if err != nil {
+		return logger.Error("Could not get current context:", err)
+	}
+	var nodesToRunDown map[string]conf.NodeConfig
+	if all {
+		nodesToRunDown = ctx.Nodes
+	} else {
+		nodesToRunDown, err = filterNodesFromContext(hosts, ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	infoString := "This will run down the following nodes:"
+	for host := range nodesToRunDown {
+		infoString += fmt.Sprintf("\n%s", host)
+	}
+	fmt.Fprintf(os.Stderr, "%s\n", infoString)
+
+	if !force && !askForConfirmation("Are you sure you want to continue?") {
+		return logger.Error("Aborted")
+	}
+
+	orchestration.RunDownNodes(nodesToRunDown)
+	return nil
+}
+
+func runUpNodes(waitForHealthy bool, audiusdTag string, hosts []string) error {
+	var nodesToRunUp map[string]conf.NodeConfig
+	ctx, err := readOrCreateContext()
+	if err != nil {
+		return logger.Error("Could not get current context:", err)
+	}
+	if len(hosts) == 0 {
+		nodesToRunUp = ctx.Nodes
+	} else {
+		nodesToRunUp, err = filterNodesFromContext(hosts, ctx)
+		if err != nil {
+			return err
+		}
+	}
+	orchestration.RunAudiusNodes(nodesToRunUp, ctx.Network, waitForHealthy, audiusdTag)
+	return nil
 }


### PR DESCRIPTION
Autocompletions will work for context and orchestration commands so you don't have to type out full hostnames anymore.

Also added a `restart` command to simplify common down-then-up workflow.

Tested by using the form `audius-ctl __complete up disc` to check completions. Tested restart on stage dn3.