### PR TITLE
Quick and easy container node ssh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,9 +153,23 @@ jobs:
             audius-ctl config dump -o "$tmpfile"
             grep 'deployOn: testnet' "$tmpfile"
       - run:
+          name: test autocompletions
+          command: |
+            audius-ctl config use-context test
+            audius-ctl config dump
+            echo checking autocomplete for contexts
+            audius-ctl __complete config use-context t | grep test
+            echo checking autocomplete for discovery provider
+            audius-ctl __complete up di | grep 'discovery-1.devnet.audius-d'
+            echo checking autocomplete for creator
+            audius-ctl __complete up cr | grep 'creator-1.devnet.audius-d'
+            echo checking autocomplete for identity service
+            audius-ctl __complete up id | grep 'identity.devnet.audius-d'
+      - run:
           name: test delete context
           command: |
             audius-ctl config delete-context test-modified
+            audius-ctl config delete-context test
             audius-ctl config  # should resort to default
             audius-ctl config current-context | grep 'default'
       - run:

--- a/cmd/audius-ctl/completions.go
+++ b/cmd/audius-ctl/completions.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/AudiusProject/audius-d/pkg/conf"
+	"github.com/AudiusProject/audius-d/pkg/logger"
+	"github.com/spf13/cobra"
+)
+
+func hostsCompletionFunction(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	hosts, err := getAvailableHostsWithPrefix(toComplete)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return hosts, cobra.ShellCompDirectiveNoFileComp
+}
+
+func contextCompletionFunction(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return getAvailableContextsWithPrefix(toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+func getAvailableHostsWithPrefix(prefix string) ([]string, error) {
+	ctx, err := readOrCreateContext()
+	if err != nil {
+		return nil, logger.Error("Could not get current context:", err)
+	}
+	hosts := make([]string, 0)
+	for host, _ := range ctx.Nodes {
+		if strings.HasPrefix(host, prefix) {
+			hosts = append(hosts, host)
+		}
+	}
+	return hosts, nil
+}
+
+func getAvailableContextsWithPrefix(prefix string) []string {
+	ctxs, err := conf.GetContexts()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		return nil
+	}
+	matches := make([]string, 0)
+	for _, ctx := range ctxs {
+		if strings.HasPrefix(ctx, prefix) {
+			matches = append(matches, ctx)
+		}
+	}
+	return matches
+}

--- a/cmd/audius-ctl/config.go
+++ b/cmd/audius-ctl/config.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/AudiusProject/audius-d/pkg/conf"
 	"github.com/AudiusProject/audius-d/pkg/logger"
@@ -187,28 +185,6 @@ func init() {
 	createContextCmd.Flags().StringVarP(&confFileTemplate, "templatefile", "f", "", "'-f <filename>' to copy context from a template file or use '-f -' to read from stdin")
 	dumpCmd.Flags().StringVarP(&dumpOutfile, "outfile", "o", "", "-o <outfile")
 	configCmd.AddCommand(dumpCmd, createContextCmd, currentContextCmd, getContextsCmd, useContextCmd, deleteContextCmd, editCmd, migrateContextCmd)
-}
-
-func contextCompletionFunction(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	if len(args) != 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	return getAvailableContextsWithPrefix(toComplete), cobra.ShellCompDirectiveNoFileComp
-}
-
-func getAvailableContextsWithPrefix(prefix string) []string {
-	ctxs, err := conf.GetContexts()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
-		return nil
-	}
-	matches := make([]string, 0)
-	for _, ctx := range ctxs {
-		if strings.HasPrefix(ctx, prefix) {
-			matches = append(matches, ctx)
-		}
-	}
-	return matches
 }
 
 func EditConfig(contextName string) error {

--- a/cmd/audius-ctl/jump.go
+++ b/cmd/audius-ctl/jump.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/AudiusProject/audius-d/pkg/orchestration"
+	"github.com/spf13/cobra"
+)
+
+var (
+	jumpCmd = &cobra.Command{
+		Use:               "jump <host>",
+		Short:             "Open a shell into the audius-d container running on a host.",
+		ValidArgsFunction: hostsCompletionFunction,
+		Args:              cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return orchestration.ShellIntoNode(args[0])
+		},
+	}
+)

--- a/cmd/audius-ctl/main.go
+++ b/cmd/audius-ctl/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	rootCmd.Flags().BoolVarP(&displayVersion, "version", "v", false, "Display version info")
-	rootCmd.AddCommand(configCmd, devnetCmd, downCmd, infraCmd, registerCmd, restartCmd, sbCmd, testCmd, upCmd)
+	rootCmd.AddCommand(configCmd, devnetCmd, downCmd, infraCmd, jumpCmd, registerCmd, restartCmd, sbCmd, testCmd, upCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/audius-ctl/up.go
+++ b/cmd/audius-ctl/up.go
@@ -91,29 +91,6 @@ func readOrCreateContext() (*conf.ContextConfig, error) {
 	return ctx_config, nil
 }
 
-func hostsCompletionFunction(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	hosts, err := getAvailableHostsWithPrefix(toComplete)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	return hosts, cobra.ShellCompDirectiveNoFileComp
-}
-
-func getAvailableHostsWithPrefix(prefix string) ([]string, error) {
-	ctx, err := readOrCreateContext()
-	if err != nil {
-		return nil, logger.Error("Could not get current context:", err)
-	}
-	hosts := make([]string, 0)
-	for host, _ := range ctx.Nodes {
-		if strings.HasPrefix(host, prefix) {
-			hosts = append(hosts, host)
-		}
-	}
-	return hosts, nil
-}
-
 func filterNodesFromContext(desired []string, ctx *conf.ContextConfig) (map[string]conf.NodeConfig, error) {
 	result := make(map[string]conf.NodeConfig)
 	for _, desiredHost := range desired {

--- a/pkg/orchestration/run.go
+++ b/pkg/orchestration/run.go
@@ -93,6 +93,22 @@ func NormalizedPrivateKey(host, privateKeyConfigValue string) (string, error) {
 	return privateKey, nil
 }
 
+func ShellIntoNode(host string) error {
+	var cmd *exec.Cmd
+	isLocalhost, err := resolvesToLocalhost(host)
+	if err != nil {
+		return logger.Error("Error determining origin of host:", err)
+	} else if isLocalhost {
+		cmd = exec.Command("docker", "exec", "-it", host, "/bin/bash")
+	} else {
+		cmd = exec.Command("ssh", "-t", host, "docker", "exec", "-it", host, "/bin/bash")
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
+}
+
 func execLocal(command string, args ...string) error {
 	cmd := exec.Command(command, args...)
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Instead of `ssh -t audius.node.example.com "docker exec -it audius.node.example.com bash"`

You can use `audius-ctl jump audius.node.example.com`

Tab autocompletions also work on hostnames.