### PR TITLE
Support miscellaneous private configuration stored on host

### DIFF
--- a/cmd/audius-ctl/jump.go
+++ b/cmd/audius-ctl/jump.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/AudiusProject/audius-d/pkg/logger"
 	"github.com/AudiusProject/audius-d/pkg/orchestration"
 	"github.com/spf13/cobra"
 )
@@ -12,6 +13,13 @@ var (
 		ValidArgsFunction: hostsCompletionFunction,
 		Args:              cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, err := readOrCreateContext()
+			if err != nil {
+				return logger.Error("Could not get current context:", err)
+			}
+			if _, ok := ctx.Nodes[args[0]]; !ok {
+				return logger.Errorf("No host named '%s' in the current context.", args[0])
+			}
 			return orchestration.ShellIntoNode(args[0])
 		},
 	}

--- a/pkg/conf/model.go
+++ b/pkg/conf/model.go
@@ -38,6 +38,7 @@ type NodeConfig struct {
 	// *** Optional fields ***
 
 	EthWallet string `yaml:"ethWallet,omitempty"`
+
 	// Specify non-standard ports for http traffic
 	HttpPort  uint `yaml:"httpPort,omitempty"`
 	HttpsPort uint `yaml:"httpsPort,omitempty"`
@@ -57,6 +58,9 @@ type NodeConfig struct {
 	// Stores any as-yet unstructured configuration
 	// (for compatibility with audius-docker-compose migrations)
 	OverrideConfig map[string]string `yaml:"overrideConfig,omitempty"`
+
+	// Path (on host machine) to env file containing additional private configuration
+	RemoteConfigFile string `yaml:"remoteConfigFile,omitempty"`
 }
 
 func NewNodeConfig(nodeType NodeType) NodeConfig {

--- a/pkg/orchestration/docker.go
+++ b/pkg/orchestration/docker.go
@@ -204,6 +204,7 @@ func runNode(
 	override := config.ToOverrideEnv(host, nconf)
 	// generate the override.env file locally
 	// WARNING: not thread safe due to constant filename
+	appendRemoteConfig(host, override, config.RemoteConfigFile)
 	localOverridePath := "./override.env"
 	if err := godotenv.Write(override, localOverridePath); err != nil {
 		return logger.Error(err)

--- a/pkg/orchestration/run.go
+++ b/pkg/orchestration/run.go
@@ -125,7 +125,7 @@ func ShellIntoNode(host string) error {
 	} else if isLocalhost {
 		cmd = exec.Command("docker", "exec", "-it", host, "/bin/bash")
 	} else {
-		cmd = exec.Command("ssh", "-t", host, "docker", "exec", "-it", host, "/bin/bash")
+		cmd = exec.Command("ssh", "-o", "ConnectTimeout=10", "-t", host, "docker", "exec", "-it", host, "/bin/bash")
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Some singleton-style configs should remain private on the host instead of stored locally in audius-d.

This feature is provisional to support migrating from audius-docker-compose to audius-d. It is not recommended for general node operators.

Also quick bug fix for jump command.