### PR TITLE
Quieter cli output, verbose logfile and option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,11 +95,11 @@ jobs:
             # move private key to file
             audius-ctl config dump | grep 'privateKey:' | head -n1 | awk '{print $2}' > /tmp/private_key
             # replace private key value with file
-            audius-ctl config dump | sed -E '0,/privateKey/{s#privateKey: [a-zA-Z0-9]+#privateKey: /tmp/private_key#}' | audius-ctl config create-context devnet -f - 
+            audius-ctl  config dump | sed -E '0,/privateKey/{s#privateKey: [a-zA-Z0-9]+#privateKey: /tmp/private_key#}' | audius-ctl config create-context devnet -f - 
 
-            audius-ctl devnet
-            audius-ctl register
-            audius-ctl up --await-healthy --audius-d-version $IMAGE_TAG
+            audius-ctl --debug devnet
+            audius-ctl --debug register
+            audius-ctl --debug up --await-healthy --audius-d-version $IMAGE_TAG
       - run:
           name: Test network status
           command: |
@@ -110,13 +110,13 @@ jobs:
           command: |
             cd ~/audius-d
             IMAGE_TAG="$(sha1sum ./Dockerfile | awk '{print $1}')"
-            audius-ctl restart discovery-1.devnet.audius-d -w -f --audius-d-version $IMAGE_TAG
+            audius-ctl --debug restart discovery-1.devnet.audius-d -w -f --audius-d-version $IMAGE_TAG
             audius-ctl status
       - run:
           name: Teardown
           command: |
             cd ~/audius-d
-            audius-ctl down -af
+            audius-ctl --debug down -af
 
   test-config-subcommands:
     docker:

--- a/cmd/audius-ctl/config.go
+++ b/cmd/audius-ctl/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -40,7 +41,7 @@ var (
 				if err != nil {
 					return logger.Error("Failed to dump config:", err)
 				}
-				logger.Out(str)
+				fmt.Println(str)
 			}
 			return nil
 		},
@@ -118,7 +119,7 @@ var (
 			if err := conf.MigrateAudiusDockerCompose(args[0], args[1]); err != nil {
 				return logger.Error("audius-docker-compose migration failed:", err)
 			}
-			logger.Info("audius-docker-compose migration successful 🎉")
+			fmt.Fprintf(os.Stderr, "audius-docker-compose migration successful 🎉\n")
 			useContextCmd.RunE(cmd, args)
 			return nil
 		},
@@ -131,7 +132,7 @@ var (
 			if err != nil {
 				return logger.Error("Failed to retrieve current context:", err)
 			}
-			logger.Out(ctx)
+			fmt.Println(ctx)
 			return nil
 		},
 	}
@@ -144,7 +145,7 @@ var (
 				return logger.Error("Failed to retrieve current context:", err)
 			}
 			for _, ctx := range ctxs {
-				logger.Out(ctx)
+				fmt.Println(ctx)
 			}
 			return nil
 		},
@@ -160,8 +161,7 @@ var (
 				return logger.Error("Failed to set context:", err)
 
 			}
-			logger.Out(args[0])
-			logger.Infof("Context set to %s", args[0])
+			fmt.Fprintf(os.Stderr, "Context set to %s\n", args[0])
 			return nil
 		},
 	}
@@ -174,8 +174,7 @@ var (
 			if err := conf.DeleteContext(args[0]); err != nil {
 				return logger.Error("Failed to delete context:", err)
 			}
-			logger.Out(args[0])
-			logger.Infof("Context %s deleted.", args[0])
+			fmt.Fprintf(os.Stderr, "Context %s deleted.\n", args[0])
 			return nil
 		},
 	}
@@ -206,8 +205,8 @@ func EditConfig(contextName string) error {
 
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
-		logger.Info("Please set $EDITOR in your shell profile to your preferred text editor.")
-		logger.Info("Defaulting to nano")
+		fmt.Fprintf(os.Stderr, "Please set $EDITOR in your shell profile to your preferred text editor.\n")
+		fmt.Fprintf(os.Stderr, "Defaulting to nano\n")
 		editor = "nano"
 	}
 

--- a/cmd/audius-ctl/main.go
+++ b/cmd/audius-ctl/main.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"fmt"
+	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/AudiusProject/audius-d/pkg/logger"
 	"github.com/spf13/cobra"
@@ -10,15 +14,21 @@ import (
 var (
 	Version        string
 	displayVersion bool
+	debugLogging   bool
 )
 
 func main() {
 	var rootCmd = &cobra.Command{
 		Use:   "audius-ctl [command]",
 		Short: "CLI for provisioning and interacting with audius nodes",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if debugLogging {
+				logger.SetCliLogLevel(slog.LevelDebug)
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if displayVersion {
-				logger.Out(Version)
+				fmt.Println(Version)
 				return
 			}
 			cmd.Help()
@@ -26,9 +36,21 @@ func main() {
 	}
 
 	rootCmd.Flags().BoolVarP(&displayVersion, "version", "v", false, "Display version info")
+	rootCmd.PersistentFlags().BoolVar(&debugLogging, "debug", false, "Print debug logs in console")
 	rootCmd.AddCommand(configCmd, devnetCmd, downCmd, infraCmd, jumpCmd, registerCmd, restartCmd, sbCmd, testCmd, upCmd)
 
+	// Handle interrupt/sigterm to mention logfile
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		fmt.Fprintf(os.Stderr, "Interrupted\n")
+		fmt.Fprintf(os.Stderr, "View full debug logs at %s\n", logger.GetLogFilepath())
+		os.Exit(1)
+	}()
+
 	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "View full debug logs at %s\n", logger.GetLogFilepath())
 		os.Exit(1)
 	}
 }

--- a/pkg/orchestration/run.go
+++ b/pkg/orchestration/run.go
@@ -58,6 +58,8 @@ func RunAudiusNodes(nodes map[string]conf.NodeConfig, network conf.NetworkConfig
 			audiusdTagOverride,
 		); err != nil {
 			logger.Warnf("Error encountered starting node %s: %s", host, err.Error())
+		} else {
+			logger.Infof("Finished spinning up %s", host)
 		}
 	}
 
@@ -68,6 +70,7 @@ func RunAudiusNodes(nodes map[string]conf.NodeConfig, network conf.NetworkConfig
 
 func RunDownNodes(nodes map[string]conf.NodeConfig) {
 	for host := range nodes {
+		logger.Infof("Spinning down %s...", host)
 		if err := downDockerNode(host); err != nil {
 			logger.Warnf("Error encountered spinning down %s: %s", host, err.Error())
 		} else {


### PR DESCRIPTION
Hide noisy orchestration logs by switching them to "debug" level and preserving them in a logfile which is referenced on failed executions. Allow debug logs to show up in console with the `--debug` flag, but hide them by default.