### PR TITLE
Simplify google application credential config

### DIFF
--- a/pkg/conf/model.go
+++ b/pkg/conf/model.go
@@ -81,6 +81,9 @@ type StorageConfig struct {
 	AzureStorageKey     string `yaml:"azureStorageKey,omitempty"`
 
 	// GCS
+	// The name of the json file containing your google application credentials,
+	// e.g. 'google-application-credentials.json' (exclude the path)
+	// Put this file in /var/k8s/mediorum/ on the host machine
 	GoogleApplicationCredentials string `yaml:"googleApplicationCredentials,omitempty"`
 }
 

--- a/pkg/conf/override.go
+++ b/pkg/conf/override.go
@@ -27,7 +27,7 @@ func (config *NodeConfig) ToOverrideEnv(host string, nc NetworkConfig) map[strin
 		if config.Storage.StorageUrl != "" {
 			overrideEnv["AUDIUS_STORAGE_DRIVER_URL"] = config.Storage.StorageUrl
 			if config.Storage.GoogleApplicationCredentials != "" {
-				overrideEnv["GOOGLE_APPLICATION_CREDENTIALS"] = config.Storage.GoogleApplicationCredentials
+				overrideEnv["GOOGLE_APPLICATION_CREDENTIALS"] = "/tmp/mediorum/" + config.Storage.GoogleApplicationCredentials
 			} else if config.Storage.AwsAccessKeyId != "" {
 				overrideEnv["AWS_ACCESS_KEY_ID"] = config.Storage.AwsAccessKeyId
 				overrideEnv["AWS_SECRET_ACCESS_KEY"] = config.Storage.AwsSecretAccessKey


### PR DESCRIPTION
The current mediorum implementation looks for google application credentials in the container's local filesystem. Because of this, it's very confusing to explain to SPs to put the .json file under `/var/k8s/mediorum/creds.json` but then to set the config value here to `/tmp/mediorum/creds.json`.

Instead, the documentation should just state that the file goes under `/var/k8s/mediorum/` on the host machine, and the config should just be set to the filename.