### PR TITLE
Force audius-d docker image rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ VOLUME ["/var/k8s/creator-node-db-15", "/var/k8s/mediorum", "/var/k8s/creator-no
 VOLUME ["/var/k8s/discovery-provider-db", "/var/k8s/discovery-provider-chain"]
 VOLUME ["/var/k8s/identity-service-db"]
 
+
 WORKDIR /root
 RUN git clone https://github.com/AudiusProject/audius-docker-compose.git ./audius-docker-compose
 WORKDIR /root/audius-docker-compose


### PR DESCRIPTION
Rebuild the audius-d docker image to get a newer version of docker compose which doesn't contain the ['extends' regression](https://github.com/docker/compose/issues/11544).