### PR TITLE
Force rebuild docker container with python requirements fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ VOLUME ["/var/k8s/creator-node-db-15", "/var/k8s/mediorum", "/var/k8s/creator-no
 VOLUME ["/var/k8s/discovery-provider-db", "/var/k8s/discovery-provider-chain"]
 VOLUME ["/var/k8s/identity-service-db"]
 
+# This comment modified 8/7/24 to force-rebuild the docker container
 
 WORKDIR /root
 RUN git clone https://github.com/AudiusProject/audius-docker-compose.git ./audius-docker-compose


### PR DESCRIPTION
Needed to add [setuptools to requirements.txt](https://github.com/AudiusProject/audius-docker-compose/pull/527) first in order to fix CI tests for release.